### PR TITLE
Make pathfinding asynchronous using WebWorker

### DIFF
--- a/app/Algorithms/bfs.ts
+++ b/app/Algorithms/bfs.ts
@@ -4,14 +4,14 @@ by using a breadth-first search. Also requires a Map (aka Hash table) with
 all of the nodes on the map provided
 */
 import { getCityData } from "../constants.ts";
+import { dataDict } from "../types.ts";
 
-export default async function bfs(city: string, start: string, end: string) {
-  const nodes = await getCityData(
-    city,
-    () => {},
-    () => {}
-  );
-
+export default async function bfs(
+  city: string,
+  start: string,
+  end: string,
+  nodes: dataDict
+) {
   //Hash table to store which vertices have been visited. Keys are the previous node in the path
   const nodesSeen: Map<string, string> = new Map<string, string>();
 

--- a/app/Algorithms/dfs.ts
+++ b/app/Algorithms/dfs.ts
@@ -1,17 +1,17 @@
 import { getCityData } from "../constants";
+import { dataDict } from "../types";
 
 interface PreviousDict {
   [key: string]: string | undefined;
 }
 
-const dfs = async (city: string, start: string, end: string) => {
-  const nodeData = await getCityData(
-    city,
-    () => {},
-    () => {}
-  );
-
-  console.log('running dfs');
+const dfs = async (
+  city: string,
+  start: string,
+  end: string,
+  nodeData: dataDict
+) => {
+  console.log("running dfs");
   let stack: Array<string> = [];
   let visitedNodes = new Set<string>();
   let previous: PreviousDict = {};
@@ -22,7 +22,7 @@ const dfs = async (city: string, start: string, end: string) => {
   while (stack.length > 0) {
     let node = stack.pop();
     if (!node) return;
-    
+
     // reached the end, reconstruct the path
     if (node === end) {
       while (previous[node]) {

--- a/app/Algorithms/dijkstras.ts
+++ b/app/Algorithms/dijkstras.ts
@@ -109,13 +109,9 @@ class Dijkstras {
 export default async function dijkstras(
   city: string,
   start: string,
-  end: string
+  end: string,
+  nodeData: dataDict
 ) {
-  const nodeData = await getCityData(
-    city,
-    () => {},
-    () => {}
-  );
   const dObject = new Dijkstras(nodeData, 2);
 
   return dObject.dijkstras(start, end);

--- a/app/Worker.ts
+++ b/app/Worker.ts
@@ -5,11 +5,9 @@ import { nodeInfo, pair, LeafletLatLng } from "./types";
 const ctx: Worker = self as any;
 
 ctx.addEventListener("message", async (event) => {
-  console.log("new message!");
+  console.log("worker received a new message!");
   const { city, algorithm, startNode, endNode } = JSON.parse(event.data);
-
   const path = await findPath(city, algorithm, startNode, endNode);
-
   ctx.postMessage(JSON.stringify({ type: "setPath", path: path }));
 });
 
@@ -19,7 +17,6 @@ const findPath = async (
   startNode: string,
   endNode: string
 ) => {
-  console.log(startNode, endNode);
   const nodeData = await getCityData(
     city,
     () => {},
@@ -30,19 +27,16 @@ const findPath = async (
   const pathfindingFunction = pathfindingModule.default;
 
   if (startNode && endNode) {
-    // call the pathfinding function with the provided parameters
-    console.log(
-      `calling ${algorithm} with parameters:`,
+    const computedPath = await pathfindingFunction(
       city,
       startNode,
-      endNode
+      endNode,
+      nodeData
     );
-    const computedPath = await pathfindingFunction(city, startNode, endNode);
-    console.log(computedPath);
 
     if (!computedPath) return;
 
-    // create an array of latlng points to draw final path
+    // create an array of latlng points for the animated polyline to draw the path
     let path: Array<LeafletLatLng> = [];
     for (const nodeId of computedPath) {
       const node: nodeInfo = nodeData[nodeId];

--- a/app/Worker.ts
+++ b/app/Worker.ts
@@ -1,0 +1,55 @@
+import { getCityData } from "./constants";
+
+import { nodeInfo, pair, LeafletLatLng } from "./types";
+
+const ctx: Worker = self as any;
+
+ctx.addEventListener("message", async (event) => {
+  console.log("new message!");
+  const { city, algorithm, startNode, endNode } = JSON.parse(event.data);
+
+  const path = await findPath(city, algorithm, startNode, endNode);
+
+  ctx.postMessage(JSON.stringify({ type: "setPath", path: path }));
+});
+
+const findPath = async (
+  city: string,
+  algorithm: string,
+  startNode: string,
+  endNode: string
+) => {
+  console.log(startNode, endNode);
+  const nodeData = await getCityData(
+    city,
+    () => {},
+    () => {}
+  );
+
+  const pathfindingModule = await import(`./algorithms/${algorithm}`);
+  const pathfindingFunction = pathfindingModule.default;
+
+  if (startNode && endNode) {
+    // call the pathfinding function with the provided parameters
+    console.log(
+      `calling ${algorithm} with parameters:`,
+      city,
+      startNode,
+      endNode
+    );
+    const computedPath = await pathfindingFunction(city, startNode, endNode);
+    console.log(computedPath);
+
+    if (!computedPath) return;
+
+    // create an array of latlng points to draw final path
+    let path: Array<LeafletLatLng> = [];
+    for (const nodeId of computedPath) {
+      const node: nodeInfo = nodeData[nodeId];
+      path.push({ lat: node.lat, lng: node.lon });
+    }
+    return path;
+  }
+};
+
+export default ctx;

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -22,25 +22,28 @@ export const cityData: cityDict = {
   ann_arbor: {
     data: {},
     file: "annarbor.json",
-    loaded: false
-  }
-}
+    loaded: false,
+  },
+};
 
 export async function getCityData(
   city: string,
   setLoading: (isLoading: boolean) => void,
   onProgress: (progress: number) => void
 ) {
+  console.log("getting data");
   if (cityData[city].loaded) {
+    console.log("data already loaded");
     return cityData[city].data;
   } else {
     const file = cityData[city].file;
     setLoading(true);
-    const { data: jsonData } = await axios.get(`./data/${file}`, {
+    const { data: jsonData } = await axios.get(`/data/${file}`, {
       onDownloadProgress: (progressEvent) => {
         if (progressEvent.total) {
           const percentage = Math.round(
-            (progressEvent.loaded * 100) / progressEvent.total);
+            (progressEvent.loaded * 100) / progressEvent.total
+          );
           onProgress(percentage);
         }
       },
@@ -51,6 +54,7 @@ export async function getCityData(
       setLoading(false);
       cityData[city].loaded = true;
     }, 200);
+    console.log("returning data");
     return cityData[city].data;
   }
 }

--- a/app/types.ts
+++ b/app/types.ts
@@ -32,3 +32,8 @@ export interface cityDict {
     loaded: boolean;
   };
 }
+
+export interface LeafletLatLng {
+  lat: number;
+  lng: number;
+}


### PR DESCRIPTION
I made the pathfinding asynchronous because pathfinding can take a long time, and since Node.js (the runtime of Javascript) is single-threaded it would block the app from doing other things until the pathfinding is complete. I'm using a WebWorker, when you click Visualize, the click handler function runPathfinding sends a message to the Worker with the information needed to execute the pathfinding. Note that the Worker thread does not have access to memory or objects in the main thread, so it loads the data for itself.

I also eliminated the loading of the city data (node data) in the pathfinding functions and instead passed the data in. See the second commit in this PR for more info.

issue #28